### PR TITLE
If the set is a collection object PID that contains underscores, for exa...

### DIFF
--- a/includes/request.inc
+++ b/includes/request.inc
@@ -662,11 +662,10 @@ function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $se
           $descendants[] = $walk_set;
         }
       }
+      $descendants[] = $value;
     }
     $walked_sets = $descendants;
 
-    $set = str_replace('_', ':', $set);
-    $walked_sets[] = $set;
     $set_fq = array();
     // We are using OR here to account for fields in Solr that may index
     // just the PID or the entire URI. In the future if performance becomes


### PR DESCRIPTION
...mple set=islandora_sp_basic_image_collection, then replacing all underscores with colons causes the query to fail.  The correct format of the collection PID (with only the first underscore switched to a colon) is already in $value, so adding $value to the descendants array fixes the query.
