### PR TITLE
Fix offset for objects whose last modified date ends with 0

### DIFF
--- a/includes/request.inc
+++ b/includes/request.inc
@@ -503,7 +503,8 @@ function islandora_oai_get_earliest_datetime() {
     $query_results = $object->repository->ri->itqlQuery($itql_query);
     $result = $query_results[0];
     $earliest_datestamp = $result['date']['value'];
-    $earliest_datestamp = drupal_substr($earliest_datestamp, 0, -5) . 'Z';
+    $earliest_datestamp_offset = preg_match('/\.\d{2}Z$/', $earliest_datestamp) ? -4 : -5;
+    $earliest_datestamp = drupal_substr($earliest_datestamp, 0, $earliest_datestamp_offset) . 'Z';
   }
   return $earliest_datestamp;
 }


### PR DESCRIPTION
This is a bit of an edge case, but for example:

``` xml
<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2014-06-17T19:39:48.970Z"/>
```

When the itql query is run this is returned as:

"object","date"
info:fedora/fedora-system:ContentModel-3.0,2014-06-17T19:39:48.97Z

Therefore the hardcoded -5 length parameter to drupal_substr
(in islandora_oai_get_earliest_datetime) contracts this to:

2014-06-17T19:39:4Z

Which will fail oai validation.

So check to see if the $earliest_datestamp has only two digits
- Z and use -4 in that case.
