### PR TITLE
Solr query backend

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -103,6 +103,17 @@ function islandora_oai_admin_form($form, $form_state) {
       ),
     ),
   );
+  $form['islandora_oai_configuration']['islandora_oai_solr_object_ancestors_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr Object Ancestors Field'),
+    '#default_value' => variable_get('islandora_oai_solr_object_ancestors_field', ''),
+    '#description' => t("A multivalued string The field in Solr that defines an object's ancestors. If left blank, Solr will have to recurse through collections manually when querying sets."),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),
+      ),
+    ),
+  );
 
   // Build up the available request handlers.
   $defined_handlers = module_invoke_all(ISLANDORA_OAI_REQUEST_HANDLER_HOOK);
@@ -170,6 +181,7 @@ function islandora_oai_admin_form_submit($form, $form_state) {
   variable_set('islandora_oai_query_backend', $form_state['values']['islandora_oai_configuration']['islandora_oai_query_backend']);
   variable_set('islandora_oai_solr_state_field', $form_state['values']['islandora_oai_configuration']['islandora_oai_solr_state_field']);
   variable_set('islandora_oai_solr_collection_description_field', $form_state['values']['islandora_oai_configuration']['islandora_oai_solr_collection_description_field']);
+  variable_set('islandora_oai_solr_object_ancestors_field', $form_state['values']['islandora_oai_configuration']['islandora_oai_solr_object_ancestors_field']);
   // Because of the dynamic pathing of the OAI path we need to rebuild the
   // menus.
   menu_rebuild();

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -71,6 +71,38 @@ function islandora_oai_admin_form($form, $form_state) {
     '#default_value' => variable_get('islandora_oai_expire_time', '86400'),
     '#description' => t('The amount of time a resumption token will remain valid, in seconds. Defaults to one day (86400s).'),
   );
+  $form['islandora_oai_configuration']['islandora_oai_query_backend'] = array(
+    '#type' => 'radios',
+    '#title' => t('Query Backend'),
+    '#default_value' => variable_get('islandora_oai_query_backend', 'sparql'),
+    '#description' => t('For larger repositories, OAI may perform poorly when attempting to order the results of SPARQL queries. In these cases, using the Solr backend may provide better results.'),
+    '#options' => array(
+      'sparql' => t('SPARQL'),
+      'solr' => t('Solr'),
+    ),
+  );
+  $form['islandora_oai_configuration']['islandora_oai_solr_state_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr Object State Field'),
+    '#default_value' => variable_get('islandora_oai_solr_state_field', 'fgs_state_s'),
+    '#description' => t("The field in Solr that holds a Fedora object's state. Must be a single-valued string type field."),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),
+      ),
+    ),
+  );
+  $form['islandora_oai_configuration']['islandora_oai_solr_collection_description_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr Collection Description Field'),
+    '#default_value' => variable_get('islandora_oai_solr_collection_description_field', 'dc.description'),
+    '#description' => t('The field in Solr to use for collection descriptions.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),
+      ),
+    ),
+  );
 
   // Build up the available request handlers.
   $defined_handlers = module_invoke_all(ISLANDORA_OAI_REQUEST_HANDLER_HOOK);
@@ -135,6 +167,9 @@ function islandora_oai_admin_form_submit($form, $form_state) {
   variable_set('islandora_oai_max_size', $form_state['values']['islandora_oai_configuration']['islandora_oai_max_size']);
   variable_set('islandora_oai_expire_time', $form_state['values']['islandora_oai_configuration']['islandora_oai_expire_time']);
   variable_set('islandora_oai_request_handler', $form_state['values']['islandora_oai_configuration']['handlers']['default']);
+  variable_set('islandora_oai_query_backend', $form_state['values']['islandora_oai_configuration']['islandora_oai_query_backend']);
+  variable_set('islandora_oai_solr_state_field', $form_state['values']['islandora_oai_configuration']['islandora_oai_solr_state_field']);
+  variable_set('islandora_oai_solr_collection_description_field', $form_state['values']['islandora_oai_configuration']['islandora_oai_solr_collection_description_field']);
   // Because of the dynamic pathing of the OAI path we need to rebuild the
   // menus.
   menu_rebuild();

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -81,38 +81,31 @@ function islandora_oai_admin_form($form, $form_state) {
       'solr' => t('Solr'),
     ),
   );
+  $solr_config_states = array(
+    'visible' => array(
+      ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),
+    ),
+  );
   $form['islandora_oai_configuration']['islandora_oai_solr_state_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Solr Object State Field'),
     '#default_value' => variable_get('islandora_oai_solr_state_field', 'fgs_state_s'),
-    '#description' => t("The field in Solr that holds a Fedora object's state. Must be a single-valued string type field."),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),
-      ),
-    ),
+    '#description' => t("The field in Solr that holds a Fedora object's state ('Active', 'Inactive', or 'Deleted')."),
+    '#states' => $solr_config_states,
   );
   $form['islandora_oai_configuration']['islandora_oai_solr_collection_description_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Solr Collection Description Field'),
     '#default_value' => variable_get('islandora_oai_solr_collection_description_field', 'dc.description'),
     '#description' => t('The field in Solr to use for collection descriptions.'),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),
-      ),
-    ),
+    '#states' => $solr_config_states,
   );
   $form['islandora_oai_configuration']['islandora_oai_solr_object_ancestors_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Solr Object Ancestors Field'),
     '#default_value' => variable_get('islandora_oai_solr_object_ancestors_field', ''),
     '#description' => t("A multivalued string The field in Solr that defines an object's ancestors. If left blank, Solr will recurse manually to get the child tree of a particular set. Use of this field may return a different set of children than the recursive option; it is the responsibility of the implementer to ensure the ancestors field returns an appropriate hierarchy of parents."),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),
-      ),
-    ),
+    '#states' => $solr_config_states,
   );
 
   // Build up the available request handlers.

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -107,7 +107,7 @@ function islandora_oai_admin_form($form, $form_state) {
     '#type' => 'textfield',
     '#title' => t('Solr Object Ancestors Field'),
     '#default_value' => variable_get('islandora_oai_solr_object_ancestors_field', ''),
-    '#description' => t("A multivalued string The field in Solr that defines an object's ancestors. If left blank, Solr will have to recurse through collections manually when querying sets."),
+    '#description' => t("A multivalued string The field in Solr that defines an object's ancestors. If left blank, Solr will recurse manually to get the child tree of a particular set. Use of this field may return a different set of children than the recursive option; it is the responsibility of the implementer to ensure the ancestors field returns an appropriate hierarchy of parents."),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_oai_configuration[islandora_oai_query_backend]"]' => array('value' => 'solr'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -75,7 +75,7 @@ function islandora_oai_admin_form($form, $form_state) {
     '#type' => 'radios',
     '#title' => t('Query Backend'),
     '#default_value' => variable_get('islandora_oai_query_backend', 'sparql'),
-    '#description' => t('For larger repositories, OAI may perform poorly when attempting to order the results of SPARQL queries. In these cases, using the Solr backend may provide better results.'),
+    '#description' => t('For larger repositories, OAI may perform poorly when attempting to perform the SPARQL queries it requires. In these cases, using the Solr backend may provide better results.'),
     '#options' => array(
       'sparql' => t('SPARQL'),
       'solr' => t('Solr'),

--- a/includes/handler.inc
+++ b/includes/handler.inc
@@ -595,7 +595,7 @@ function islandora_oai_query_solr_for_child_sets($parent, &$sets = array()) {
   $qp->solrParams['fq'] = array();
   module_invoke('islandora_xacml_api', 'islandora_solr_query', $qp);
   // Set is part of the current collection.
-  $qp->solrParams['fq'][] = islandora_oai_build_membership_fq_statement($parent);
+  $qp->solrParams['fq'][] = islandora_oai_build_membership_fq_statement(array($parent));
   // Set is also a collection itself.
   $qp->solrParams['fq'][] = format_string('!field:"info:fedora/islandora:collectionCModel"', array(
     '!field' => variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms'),

--- a/includes/handler.inc
+++ b/includes/handler.inc
@@ -435,7 +435,7 @@ function islandora_oai_datetime_to_solr_time($datetime, $until = FALSE) {
  * @param string $query
  *   Query string to search for.
  * @param bool $set
- *   Whether we are querying down for a set which requires walking in ITQL land.
+ *   Whether we are recursively querying through a set.
  * @param bool $date_query
  *   Whether this is a date query or not.
  *
@@ -443,8 +443,6 @@ function islandora_oai_datetime_to_solr_time($datetime, $until = FALSE) {
  *   The results generated from the crafted Solr query.
  */
 function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $set = NULL, $date_query = NULL) {
-  global $user;
-
   $query_processor = new IslandoraSolrQueryProcessor();
 
   // Build the query string.
@@ -452,20 +450,21 @@ function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $se
     $query = '*:*';
   }
   else {
-    $query = $field . ':' . Apache_Solr_Service::escape($query);
+    module_load_include('inc', 'islandora_solr', 'includes/utilities');
+    $query = $field . ':' . islandora_solr_lesser_escape($query);
   }
-
   $query_processor->buildQuery($query);
 
+  // Build the fields to return.
   $fl_fields = islandora_oai_get_membership_array();
   $fl_fields[] = 'PID';
   $fl_fields[] = variable_get('islandora_oai_date_field', 'fgs_lastModifiedDate_dt');
   $query_processor->solrParams['fl'] = implode(',', $fl_fields);
 
+  // Build the filter array.
   if ($date_query) {
     $query_processor->solrParams['fq'][] = $date_query;
   }
-
   $exclude_content_models = islandora_oai_get_restricted_models();
   $has_model = variable_get('islandora_oai_content_model_field', 'RELS_EXT_hasModel_uri_ms');
   foreach ($exclude_content_models as $content_model) {
@@ -474,150 +473,67 @@ function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $se
       $query_processor->solrParams['fq'][] = '(-' . $has_model . ':("' . $content_model . '" OR "info:fedora/' . $content_model . '"))';
     }
   }
+
+  // Recurse through sets if necessary.
   if ($set) {
     // OAI uses : to separate multiple setSpecs so we had to replace it
     // from the pids earlier.
     $sets = explode(':', $set);
+    // Replace the first occurrence of _ with a : so we are back to a
+    // valid pid.
+    $repair_sets = function(&$set) {
+      $set = preg_replace('/_/', ':', $set, 1);
+      $set = trim($set);
+    };
+    array_walk($sets, $repair_sets);
     $descendants = array();
 
-    if ($user->uid === 0) {
-      $user_name = 'anonymous';
-    }
-    else {
-      $user_name = $user->name;
-    }
-
-    // Get all descendant children (collection and objs) and add to the sets
-    // array if not already existing.
-    // Cannot constrain on collections only as name conventions may change
-    // across implementations.
-    foreach ($sets as $key => $value) {
-      // Replace the first occurrence of _ with a : so we are back to a
-      // valid pid.
-      $value = preg_replace('/_/', ':', $value, 1);
-      $value = trim($value);
-      $sets[$key] = $value;
-
-      $connection = islandora_get_tuque_connection();
-      if (!variable_get('islandora_risearch_use_itql_when_necessary', TRUE)) {
-        $role_filters = array();
-        foreach ($user->roles as $role) {
-          $role_filters[] = "?role = \"$role\"";
+    switch (variable_get('islandora_oai_query_backend', 'sparql')) {
+      case 'sparql':
+        // Get all descendant children (collection and objs) and add to the sets
+        // array if not already existing.
+        // Cannot constrain on collections only as name conventions may change
+        // across implementations.
+        foreach ($sets as $value) {
+          $query_results = islandora_oai_query_ri_for_child_sets($value);
+          foreach ($query_results as $result) {
+            $walk_set = $result['child']['uri'];
+            $walk_set = str_replace('info:fedora/', '', $walk_set);
+            if (!in_array($walk_set, $descendants)) {
+              $descendants[] = $walk_set;
+            }
+          }
+          $descendants[] = $value;
         }
-        $xacml_filters = array(
-          '!bound(?role) && !bound(?user)',
-          'bound(?role) && (' . implode(' || ', $role_filters) . ')',
-          "bound(?user) && ?user = '$user_name'",
-        );
-        $parenthesis_wrap = function($string) {
-          return "($string)";
-        };
-        $xacml_filter = implode(' || ', array_map($parenthesis_wrap, $xacml_filters));
-        $query = <<<EOQ
-SELECT ?child
-FROM <#ri>
-WHERE {
-  ?child <fedora-model:state> <fedora-model:Active> .
-  {
-    ?child <fedora-model:hasModel> <info:fedora/islandora:collectionCModel>
-  } UNION {
-    ?child <fedora-model:hasModel> [<fedora-model:hasModel> <info:fedora/islandora:collectionCModel>]
-  } .
-  {
-    ?child <fedora-rels-ext:isMemberOfCollection>+ <info:fedora/$value>
-  } UNION {
-    ?child <fedora-rels-ext:isMemberOf>+ <info:fedora/$value>
-  }
-  OPTIONAL {
-    ?child <http://islandora.ca/ontology/relsext#isViewableByRole> ?role .
-  }
-  OPTIONAL {
-    ?child <http://islandora.ca/ontology/relsext#isViewableByUser> ?user .
-  }
-  FILTER($xacml_filter)
-}
-EOQ;
-        $query_results = $connection->repository->ri->sparqlQuery($query);
-      }
-      else {
-        $itql_query = '
-        select $child from <#ri>
-        where
-        (
-          (
-            (
-            $child <fedora-model:hasModel> $model
-            and $model <mulgara:is> <info:fedora/islandora:collectionCModel>
-            and $model <fedora-model:hasModel> <info:fedora/fedora-system:ContentModel-3.0>
-            )
-          or
-            (
-            $child <fedora-model:hasModel> $model
-            and $model <fedora-model:hasModel> <info:fedora/islandora:collectionCModel>
-            and $child <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
-            )
-          minus $child <http://islandora.ca/ontology/relsext#isViewableByRole> $role
-          minus $child <http://islandora.ca/ontology/relsext#isViewableByUser> $user
-          )
-        or
-          (
-            (
-            $child <fedora-model:hasModel> $model
-            and $model <mulgara:is> <info:fedora/islandora:collectionCModel>
-            and $model <fedora-model:hasModel> <info:fedora/fedora-system:ContentModel-3.0>
-            )
-          or
-            (
-            $child <fedora-model:hasModel> $model
-            and $model <fedora-model:hasModel> <info:fedora/islandora:collectionCModel>
-            and $child <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
-            )
-        and
-            (';
-        foreach ($user->roles as $role) {
-          $itql_query .= '$child <http://islandora.ca/ontology/relsext#isViewableByRole> ' . "'$role' or ";
-        }
-        $itql_query .= '$child <http://islandora.ca/ontology/relsext#isViewableByUser> ' . "'$user_name'" . ')';
-        $itql_query .= ')
-        )
-      and
-        (
-        walk
-          (
-            $parent <fedora-rels-ext:isMemberOfCollection><info:fedora/' . $value . '>
-             and $child <fedora-rels-ext:isMemberOfCollection> $parent
-          )
-        or
-        walk
-          (
-            $parent <fedora-rels-ext:isMemberOf><info:fedora/' . $value . '>
-            and $child <fedora-rels-ext:isMemberOf> $parent
-          )
-      )';
+        $query_processor->solrParams['fq'][] = islandora_oai_build_descendants_fq_statement($descendants);
+        break;
 
-        $query_results = $connection->repository->ri->itqlQuery($itql_query);
-      }
-      foreach ($query_results as $result) {
-        $walk_set = $result['child']['uri'];
-        $walk_set = str_replace('info:fedora/', '', $walk_set);
-        if (!in_array($walk_set, $descendants)) {
-          $descendants[] = $walk_set;
+      case 'solr':
+        // Easier if we have ancestors.
+        $ancestors_field = variable_get('islandora_oai_solr_object_ancestors_field', '');
+        if (!empty($ancestors_field)) {
+          foreach ($sets as $value) {
+            $query_processor->solrParams['fq'][] = format_string('!ancestors_field:("!pid" OR "info:fedora/!pid")', array(
+              '!ancestors_field' => $ancestors_field,
+              '!pid' => $value,
+            ));
+          }
         }
-      }
-      $descendants[] = $value;
+        // Otherwise we have to recurse manually.
+        else {
+          foreach ($sets as $value) {
+            $query_results = islandora_oai_query_solr_for_child_sets($value);
+            foreach ($query_results as $result) {
+              if (!in_array($result, $descendants)) {
+                $descendants[] = $result;
+              }
+            }
+            $descendants[] = $value;
+          }
+          $query_processor->solrParams['fq'][] = islandora_oai_build_descendants_fq_statement($descendants);
+        }
+        break;
     }
-    $walked_sets = $descendants;
-
-    $set_fq = array();
-    // We are using OR here to account for fields in Solr that may index
-    // just the PID or the entire URI. In the future if performance becomes
-    // an issue with huge Solr queries we should re-visit this.
-    foreach ($walked_sets as $walk) {
-      foreach (islandora_oai_get_membership_array() as $collection_field) {
-        $set_fq[] = $collection_field . ':("' . $walk . '" OR "info:fedora/' . $walk . '")';
-      }
-    }
-    $query_processor->solrParams['fq'][] = '(' . implode(' OR ', $set_fq) . ')';
   }
   $query_processor->solrStart = $start;
   $query_processor->solrLimit = variable_get('islandora_oai_max_size', '20');
@@ -629,6 +545,196 @@ EOQ;
     drupal_set_message(t('error searching @message', array('@message' => $e->getMessage())), 'error');
   }
   return $solr_results;
+}
+
+/**
+ * Helper function to build an 'fq' statement from a descentants array.
+ *
+ * @param array $descendants
+ *   The array of descendant collection PIDs.
+ *
+ * @return string
+ *   The 'fq' statement.
+ */
+function islandora_oai_build_descendants_fq_statement(array $descendants) {
+  $set_fq = array();
+  // We are using OR here to account for fields in Solr that may index
+  // just the PID or the entire URI. In the future if performance becomes
+  // an issue with huge Solr queries we should re-visit this.
+  foreach ($descendants as $walk) {
+    foreach (islandora_oai_get_membership_array() as $collection_field) {
+      $set_fq[] = $collection_field . ':("' . $walk . '" OR "info:fedora/' . $walk . '")';
+    }
+  }
+  return '(' . implode(' OR ', $set_fq) . ')';
+}
+
+/**
+ * Helper function to query recursively for child sets from Solr.
+ *
+ * @param string $parent
+ *   The set to get children in.
+ * @param array $sets
+ *   Used internally to maintain the list of sets found as it recurses.
+ *
+ * @return array
+ *   A list of set PIDs.
+ */
+function islandora_oai_query_solr_for_child_sets($parent, &$sets = array()) {
+  global $user;
+  $user_name = $user->uid === 0 ? 'anonymous' : $user->name;
+
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildQuery('*:*');
+  $qp->solrParams['fl'] = 'PID';
+  // Make sure we get everything but still filter on XACML permissions.
+  $qp->solrParams['fq'] = array();
+  if (module_exists('islandora_xacml_api')) {
+    module_invoke('islandora_xacml_api', 'islandora_solr_query', $qp);
+  }
+  // Is part of the current collection.
+  $collection_fields = explode("\n", variable_get('islandora_oai_collection_field', "RELS_EXT_isMemberOfCollection_uri_ms\nRELS_EXT_isMemberOf_uri_ms"));
+  $collection_filter = array();
+  foreach ($collection_fields as $collection_field) {
+    $collection_filter[] = format_string('!field:("!set" OR "info:fedora/!set")', array(
+      '!field' => $collection_field,
+      '!set' => $parent,
+    ));
+  }
+  $qp->solrParams['fq'][] = '(' . implode(' OR ', $collection_filter) . ')';
+  // Is also a collection itself.
+  $qp->solrParams['fq'][] = format_string('!field:"info:fedora/islandora:collectionCModel"', array(
+    '!field' => variable_get('islandora_oai_content_model_field', 'RELS_EXT_hasModel_uri_ms'),
+  ));
+
+  $qp->executeQuery(FALSE);
+  $get_pid = function($object) {
+    return $object['PID'];
+  };
+  $pids = array_map($get_pid, $qp->islandoraSolrResult['response']['objects']);
+  $diff = array_diff($pids, $sets);
+  $sets = array_merge($sets, $pids);
+  foreach ($diff as $child_collection) {
+    islandora_oai_query_solr_for_child_sets($child_collection, $sets);
+  }
+  return $sets;
+}
+
+/**
+ * Helper function to query for child sets from the RI.
+ *
+ * @param string $set
+ *   The PID of the set to query in.
+ *
+ * @return array
+ *   The results of the RI query from Tuque.
+ */
+function islandora_oai_query_ri_for_child_sets($set) {
+  global $user;
+  $user_name = $user->uid === 0 ? 'anonymous' : $user->name;
+
+  $connection = islandora_get_tuque_connection();
+  // Query sets from RI (SPARQL).
+  if (!variable_get('islandora_risearch_use_itql_when_necessary', TRUE)) {
+    $role_filters = array();
+    foreach ($user->roles as $role) {
+      $role_filters[] = "?role = \"$role\"";
+    }
+    $xacml_filters = array(
+      '!bound(?role) && !bound(?user)',
+      'bound(?role) && (' . implode(' || ', $role_filters) . ')',
+      "bound(?user) && ?user = '$user_name'",
+    );
+    $parenthesis_wrap = function($string) {
+      return "($string)";
+    };
+    $xacml_filter = implode(' || ', array_map($parenthesis_wrap, $xacml_filters));
+    $query = <<<EOQ
+SELECT ?child
+FROM <#ri>
+WHERE {
+  ?child <fedora-model:state> <fedora-model:Active> .
+  {
+    ?child <fedora-model:hasModel> <info:fedora/islandora:collectionCModel>
+  } UNION {
+    ?child <fedora-model:hasModel> [<fedora-model:hasModel> <info:fedora/islandora:collectionCModel>]
+  } .
+  {
+    ?child <fedora-rels-ext:isMemberOfCollection>+ <info:fedora/$set>
+  } UNION {
+    ?child <fedora-rels-ext:isMemberOf>+ <info:fedora/$set>
+  }
+  OPTIONAL {
+    ?child <http://islandora.ca/ontology/relsext#isViewableByRole> ?role .
+  }
+  OPTIONAL {
+    ?child <http://islandora.ca/ontology/relsext#isViewableByUser> ?user .
+  }
+  FILTER($xacml_filter)
+}
+EOQ;
+    $query_results = $connection->repository->ri->sparqlQuery($query);
+  }
+  // Query sets from RI (iTQL).
+  else {
+    $itql_query = '
+    select $child from <#ri>
+    where
+    (
+      (
+        (
+        $child <fedora-model:hasModel> $model
+        and $model <mulgara:is> <info:fedora/islandora:collectionCModel>
+        and $model <fedora-model:hasModel> <info:fedora/fedora-system:ContentModel-3.0>
+        )
+      or
+        (
+        $child <fedora-model:hasModel> $model
+        and $model <fedora-model:hasModel> <info:fedora/islandora:collectionCModel>
+        and $child <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
+        )
+      minus $child <http://islandora.ca/ontology/relsext#isViewableByRole> $role
+      minus $child <http://islandora.ca/ontology/relsext#isViewableByUser> $user
+      )
+    or
+      (
+        (
+        $child <fedora-model:hasModel> $model
+        and $model <mulgara:is> <info:fedora/islandora:collectionCModel>
+        and $model <fedora-model:hasModel> <info:fedora/fedora-system:ContentModel-3.0>
+        )
+      or
+        (
+        $child <fedora-model:hasModel> $model
+        and $model <fedora-model:hasModel> <info:fedora/islandora:collectionCModel>
+        and $child <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
+        )
+    and
+        (';
+    foreach ($user->roles as $role) {
+      $itql_query .= '$child <http://islandora.ca/ontology/relsext#isViewableByRole> ' . "'$role' or ";
+    }
+    $itql_query .= '$child <http://islandora.ca/ontology/relsext#isViewableByUser> ' . "'$user_name'" . ')';
+    $itql_query .= ')
+    )
+  and
+    (
+    walk
+      (
+        $parent <fedora-rels-ext:isMemberOfCollection><info:fedora/' . $set . '>
+         and $child <fedora-rels-ext:isMemberOfCollection> $parent
+      )
+    or
+    walk
+      (
+        $parent <fedora-rels-ext:isMemberOf><info:fedora/' . $set . '>
+        and $child <fedora-rels-ext:isMemberOf> $parent
+      )
+  )';
+    $query_results = $connection->repository->ri->itqlQuery($itql_query);
+  }
+  return $query_results;
 }
 
 /**

--- a/includes/handler.inc
+++ b/includes/handler.inc
@@ -24,38 +24,82 @@
  * @see hook_islandora_oai_identify_request_handler()
  */
 function islandora_oai_retrieve_sets($params) {
-  $connection = islandora_get_tuque_connection();
-  $records = array();
-  $filters = array('sameTerm(?model, <info:fedora/islandora:collectionCModel>)');
-  $sparql_query = islandora_oai_construct_sparql_query_for_sets($filters);
-  $total_records = $connection->repository->ri->countQuery($sparql_query, 'sparql');
-  $sparql_query .= <<<EOQ
-  LIMIT {$params['max_records']}
-  OFFSET {$params['token']->deliveredrecords}
+  switch (variable_get('islandora_oai_query_backend', 'sparql')) {
+    case 'sparql':
+      $connection = islandora_get_tuque_connection();
+      $records = array();
+      $filters = array('sameTerm(?model, <info:fedora/islandora:collectionCModel>)');
+      $sparql_query = islandora_oai_construct_sparql_query_for_sets($filters);
+      $total_records = $connection->repository->ri->countQuery($sparql_query, 'sparql');
+      $sparql_query .= <<<EOQ
+
+LIMIT {$params['max_records']}
+OFFSET {$params['token']->deliveredrecords}
 EOQ;
-  $query_results = $connection->repository->ri->sparqlQuery($sparql_query);
-  module_load_include('inc', 'islandora', 'includes/dublin_core');
-  foreach ($query_results as $result) {
-    $object = islandora_object_load($result['object']['value']);
-    $description = FALSE;
-    if (isset($object['DC'])) {
-      $dom = new DOMDocument();
-      $dom->loadXML($object['DC']->content);
-      $description = $dom->saveXML($dom->documentElement);
-    }
-    $pid = $result['object']['value'];
-    $records[$pid] = array(
-      'pid' => $pid,
-      'label' => $result['title']['value'],
-    );
-    if ($description) {
-      $records[$pid]['description'] = $description;
-    }
+      $query_results = $connection->repository->ri->sparqlQuery($sparql_query);
+      foreach ($query_results as $result) {
+        $object = islandora_object_load($result['object']['value']);
+        $description = FALSE;
+        if (isset($object['DC'])) {
+          $description = islandora_oai_get_set_dc_portion($object['DC']);
+        }
+        $pid = $result['object']['value'];
+        $records[$pid] = array(
+          'pid' => $pid,
+          'label' => $result['title']['value'],
+        );
+        if ($description) {
+          $records[$pid]['description'] = $description;
+        }
+      }
+      break;
+
+    case 'solr':
+      $qp = new IslandoraSolrQueryProcessor();
+      $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');
+      $solr_params = array(
+        'limit' => $params['max_records'],
+        'sort' => $label_field,
+      );
+      $qp->buildQuery(format_string('!field:"info:fedora/islandora:collectionCModel"', array(
+        '!field' => variable_get('islandora_oai_content_model_field', 'RELS_EXT_hasModel_uri_ms'),
+      )), $solr_params);
+      $qp->solrStart = $params['token']->deliveredrecords;
+      $qp->executeQuery(FALSE);
+      $total_records = $qp->islandoraSolrResult['response']['numFound'];
+      $records = array();
+      $datastreams_field = variable_get('islandora_solr_datastream_id_field', 'fedora_datastreams_ms');
+      foreach ($qp->islandoraSolrResult['response']['objects'] as $object) {
+        $records[$object['PID']] = array(
+          'pid' => $object['PID'],
+          'label' => $object['solr_doc'][$label_field],
+        );
+        if (isset($object['solr_doc'][$datastreams_field]) && in_array('DC', $object['solr_doc'][$datastreams_field])) {
+          $loaded_object = islandora_object_load($object['PID']);
+          $records[$object['PID']]['description'] = islandora_oai_get_set_dc_portion($loaded_object['DC']);
+        }
+      }
+      break;
   }
   return array(
     'total_records' => $total_records,
     'records' => $records,
   );
+}
+
+/**
+ * Gets the DC portion of a set.
+ *
+ * @param AbstractDatastream $dc
+ *   The DC XML datastream.
+ *
+ * @return string
+ *   The XML to add to the set info.
+ */
+function islandora_oai_get_set_dc_portion(AbstractDatastream $dc) {
+  $dom = new DOMDocument();
+  $dom->loadXML($dc->content);
+  return $dom->saveXML($dom->documentElement);
 }
 
 /**
@@ -636,6 +680,7 @@ function islandora_oai_get_restricted_models() {
  *   The SPARQL query to be executed.
  */
 function islandora_oai_construct_sparql_query_for_sets($filters, $required = array()) {
+  module_load_include('inc', 'islandora', 'includes/tuque');
   $sparql_query = <<<EOQ
   SELECT DISTINCT ?object ?title ?created !vars
   FROM <#ri>

--- a/includes/handler.inc
+++ b/includes/handler.inc
@@ -62,7 +62,7 @@ EOQ;
         'sort' => $label_field,
       );
       $qp->buildQuery(format_string('!field:"info:fedora/islandora:collectionCModel"', array(
-        '!field' => variable_get('islandora_oai_content_model_field', 'RELS_EXT_hasModel_uri_ms'),
+        '!field' => variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms'),
       )), $solr_params);
       $qp->solrStart = $params['token']->deliveredrecords;
       $qp->executeQuery(FALSE);
@@ -505,7 +505,7 @@ function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $se
           }
           $descendants[] = $value;
         }
-        $query_processor->solrParams['fq'][] = islandora_oai_build_descendants_fq_statement($descendants);
+        $query_processor->solrParams['fq'][] = islandora_oai_build_membership_fq_statement($descendants);
         break;
 
       case 'solr':
@@ -530,7 +530,7 @@ function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $se
             }
             $descendants[] = $value;
           }
-          $query_processor->solrParams['fq'][] = islandora_oai_build_descendants_fq_statement($descendants);
+          $query_processor->solrParams['fq'][] = islandora_oai_build_membership_fq_statement($descendants);
         }
         break;
     }
@@ -548,25 +548,28 @@ function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $se
 }
 
 /**
- * Helper function to build an 'fq' statement from a descentants array.
+ * Helper function to build an 'fq' statement for child PIDs.
  *
- * @param array $descendants
- *   The array of descendant collection PIDs.
+ * @param array $children
+ *   The array of child PIDs.
  *
  * @return string
  *   The 'fq' statement.
  */
-function islandora_oai_build_descendants_fq_statement(array $descendants) {
+function islandora_oai_build_membership_fq_statement(array $children) {
   $set_fq = array();
   // We are using OR here to account for fields in Solr that may index
   // just the PID or the entire URI. In the future if performance becomes
   // an issue with huge Solr queries we should re-visit this.
-  foreach ($descendants as $walk) {
+  foreach ($children as $walk) {
     foreach (islandora_oai_get_membership_array() as $collection_field) {
-      $set_fq[] = $collection_field . ':("' . $walk . '" OR "info:fedora/' . $walk . '")';
+      $set_fq[] = format_string('!field:("!walk" OR "info:fedora/!walk")', array(
+        '!field' => $collection_field,
+        '!walk' => $walk,
+      ));
     }
   }
-  return '(' . implode(' OR ', $set_fq) . ')';
+  return implode(' OR ', $set_fq);
 }
 
 /**
@@ -590,22 +593,12 @@ function islandora_oai_query_solr_for_child_sets($parent, &$sets = array()) {
   $qp->solrParams['fl'] = 'PID';
   // Make sure we get everything but still filter on XACML permissions.
   $qp->solrParams['fq'] = array();
-  if (module_exists('islandora_xacml_api')) {
-    module_invoke('islandora_xacml_api', 'islandora_solr_query', $qp);
-  }
-  // Is part of the current collection.
-  $collection_fields = explode("\n", variable_get('islandora_oai_collection_field', "RELS_EXT_isMemberOfCollection_uri_ms\nRELS_EXT_isMemberOf_uri_ms"));
-  $collection_filter = array();
-  foreach ($collection_fields as $collection_field) {
-    $collection_filter[] = format_string('!field:("!set" OR "info:fedora/!set")', array(
-      '!field' => $collection_field,
-      '!set' => $parent,
-    ));
-  }
-  $qp->solrParams['fq'][] = '(' . implode(' OR ', $collection_filter) . ')';
-  // Is also a collection itself.
+  module_invoke('islandora_xacml_api', 'islandora_solr_query', $qp);
+  // Set is part of the current collection.
+  $qp->solrParams['fq'][] = islandora_oai_build_membership_fq_statement($parent);
+  // Set is also a collection itself.
   $qp->solrParams['fq'][] = format_string('!field:"info:fedora/islandora:collectionCModel"', array(
-    '!field' => variable_get('islandora_oai_content_model_field', 'RELS_EXT_hasModel_uri_ms'),
+    '!field' => variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms'),
   ));
 
   $qp->executeQuery(FALSE);
@@ -615,6 +608,7 @@ function islandora_oai_query_solr_for_child_sets($parent, &$sets = array()) {
   $pids = array_map($get_pid, $qp->islandoraSolrResult['response']['objects']);
   $diff = array_diff($pids, $sets);
   $sets = array_merge($sets, $pids);
+  // Recurse through the diff.
   foreach ($diff as $child_collection) {
     islandora_oai_query_solr_for_child_sets($child_collection, $sets);
   }
@@ -637,19 +631,7 @@ function islandora_oai_query_ri_for_child_sets($set) {
   $connection = islandora_get_tuque_connection();
   // Query sets from RI (SPARQL).
   if (!variable_get('islandora_risearch_use_itql_when_necessary', TRUE)) {
-    $role_filters = array();
-    foreach ($user->roles as $role) {
-      $role_filters[] = "?role = \"$role\"";
-    }
-    $xacml_filters = array(
-      '!bound(?role) && !bound(?user)',
-      'bound(?role) && (' . implode(' || ', $role_filters) . ')',
-      "bound(?user) && ?user = '$user_name'",
-    );
-    $parenthesis_wrap = function($string) {
-      return "($string)";
-    };
-    $xacml_filter = implode(' || ', array_map($parenthesis_wrap, $xacml_filters));
+    $xacml_filter = module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_filters');
     $query = <<<EOQ
 SELECT ?child
 FROM <#ri>

--- a/includes/request.inc
+++ b/includes/request.inc
@@ -498,6 +498,7 @@ SELECT ?object ?date
 FROM <#ri>
 WHERE {
   ?object <fedora-model:state> <fedora-model:Active> ;
+          <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> ;
           <fedora-view:lastModifiedDate> ?date .
 }
 ORDER BY ?date

--- a/includes/request.inc
+++ b/includes/request.inc
@@ -491,22 +491,42 @@ function islandora_oai_identify(&$writer, $args) {
 function islandora_oai_get_earliest_datetime() {
   static $earliest_datestamp;
   if (!$earliest_datestamp) {
-    $query = <<<EOQ
+    switch (variable_get('islandora_oai_query_backend', 'sparql')) {
+      case 'sparql':
+        $query = <<<EOQ
 SELECT ?object ?date
 FROM <#ri>
 WHERE {
-  ?object <fedora-model:label> ?title ;
-          <fedora-model:state> <fedora-model:Active> ;
+  ?object <fedora-model:state> <fedora-model:Active> ;
           <fedora-view:lastModifiedDate> ?date .
 }
 ORDER BY ?date
 LIMIT 1
 EOQ;
-    $connection = islandora_get_tuque_connection();
-    $query_results = $connection->repository->ri->sparqlQuery($query);
-    $result = reset($query_results);
-    $timestamp = strtotime($result['date']['value']);
-    $earliest_datestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
+        $connection = islandora_get_tuque_connection();
+        $query_results = $connection->repository->ri->sparqlQuery($query);
+        $result = reset($query_results);
+        $timestamp = strtotime($result['date']['value']);
+        $earliest_datestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
+        break;
+
+      case 'solr':
+        $date_field = variable_get('islandora_oai_date_field', 'fgs_lastModifiedDate_dt');
+        $qp = new IslandoraSolrQueryProcessor();
+        $params = array(
+          'sort' => "$date_field asc",
+          'limit' => 1,
+        );
+        $qp->buildQuery(format_string('!date_field:* AND !state_field:Active', array(
+          '!date_field' => $date_field,
+          '!state_field' => variable_get('islandora_oai_solr_state_field', 'fgs_state_s'),
+        )));
+        $qp->executeQuery(FALSE);
+        $result = reset($qp->islandoraSolrResult['response']['objects']);
+        $earliest_datestamp = $result['solr_doc'][$date_field];
+        break;
+
+    }
   }
   return $earliest_datestamp;
 }

--- a/islandora_oai.install
+++ b/islandora_oai.install
@@ -185,6 +185,9 @@ function islandora_oai_uninstall() {
     'islandora_oai_exclude_content_models',
     'islandora_oai_exclude_islandora_namespace',
     'islandora_oai_append_dc_thumbnail',
+    'islandora_oai_query_backend',
+    'islandora_oai_solr_state_field',
+    'islandora_oai_solr_collection_description_field',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_oai.install
+++ b/islandora_oai.install
@@ -188,6 +188,7 @@ function islandora_oai_uninstall() {
     'islandora_oai_query_backend',
     'islandora_oai_solr_state_field',
     'islandora_oai_solr_collection_description_field',
+    'islandora_oai_solr_object_ancestors_field',
   );
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1778
# What does this Pull Request do?

Adds a Solr query backend to OAI queries that use ORDER BY statements so that if your repository has a ton of objects and/or collections, these can be sorted (by dateLastModified and label) much more promptly.

Also adds an alternative for the query that recursively grabs sets as this can be done through Solr as well.
# What's new?
- Ability to use Solr to provide the ListSets, Identify `earliestDatestamp` information, and recursive set-grabbing.
- Some new configuration options on the admin screen dealing with switching the backend, as well as required fields for its usage.
# How should this be tested?

There's a test case listed on the associated JIRA ticket that can be followed.
# Additional Notes:

A couple errors have been fixed in the process of this - stuff that was broken and needed to be fixed. Namely:
- `islandora_oai_get_earliest_timestamp()` was returning useless info and had the potential of returning datastreams, which doesn't work for the OAI spec. This has been patched in this PR because otherwise, the Solr backend - which only returns objects - could potentially report a different `earliestDatestamp` than the SPARQL backend.
- `islandora_oai_construct_sparql_query_for_sets()` failed to load Tuque before attempting to use `ISLANDORA_RELS_EXT_URI`, which silently errored. This has been patched in this PR as it affects both backends.
# Interested parties

@jordandukart who is the maintainer and all-around OAI master for life
