### PR TITLE
Make listsets only respond with active collections

### DIFF
--- a/includes/handler.inc
+++ b/includes/handler.inc
@@ -779,7 +779,8 @@ function islandora_oai_construct_sparql_query_for_sets($filters, $required = arr
   WHERE {
     ?object <fedora-model:hasModel> ?model ;
             <fedora-model:label> ?title ;
-            <fedora-model:createdDate> ?created .
+            <fedora-model:createdDate> ?created ;
+            <fedora-model:state> <fedora-model:Active> .
     !required
     !optionals
     !filters


### PR DESCRIPTION
When we look for sets within sets we only look for active objects,
but when just doing a normal listsets we respond with inactive sets.

**JIRA Ticket**:
https://jira.duraspace.org/browse/ISLANDORA-1897

# What does this Pull Request do?

When using the SPARQL query provider the OAI module will return inactive collections to a ListSets request. This pull request fixes that.

When we are looking for child sets we do make sure they are active. Its just the top level set query that ignores inactive. 

This query doesn't specify active:
https://github.com/Islandora/islandora_oai/blob/7.x/includes/handler.inc#L777-L787
but this one does:
https://github.com/Islandora/islandora_oai/blob/7.x/includes/handler.inc#L643

# What's new?

Update the SPARQL query used to list sets to only find active sets.

# How should this be tested?

* Make a collection
* Make a second collection and set it to inactive
* Go the the OAI list sets URL
* Before the patch you should see the inactive object, after you should not.

# Interested parties
@jordandukart @Islandora/7-x-1-x-committers 