### PR TITLE
Work on ISLANDORA-2120.

### DIFF
--- a/includes/handler.inc
+++ b/includes/handler.inc
@@ -250,6 +250,10 @@ function islandora_oai_object_response_xml($params) {
         '@datastream' => $param,
       ), WATCHDOG_ERROR);
   }
+
+  // Allow modules to alter the OAI-PMH record.
+  drupal_alter('islandora_oai_record', $oai_output, $params);
+
   return $oai_output;
 }
 

--- a/islandora_oai.api.php
+++ b/islandora_oai.api.php
@@ -147,3 +147,31 @@ function hook_islandora_oai_identify_request_handler() {
  */
 function hook_islandora_oai_self_transform_params($object, $metadata_prefix) {
 }
+
+/**
+ * Allows modules to alter the DC, MODS, etc. OAI-PMH record.
+ *
+ * @param string $oai_record
+ *   The serialized XML OAI record.
+ * @param array $params
+ *   An array containing:
+ *   -metadata_prefix (string): The metadata prefix of the request being
+ *   executed.
+ *   -pid (string): The pid of the object described in the record.
+ */
+function hook_islandora_oai_record_alter(&$oai_record, &$params) {
+  if (ip_address() == '123.456.789.789' && $params['metadata_prefix'] == 'oai_dc') {
+    $rights_value = "We want a custom rights statement.";
+    $rights_element = "<dc:rights>" . $rights_value . "</dc:rights>";
+
+    $dom = new DOMDocument();
+    $dom->preserveWhiteSpace = FALSE;
+    $dom->formatOutput = TRUE;
+    $dom->loadXML($oai_record);
+    $frag = $dom->createDocumentFragment();
+    $frag->appendXML($rights_element);
+    $dom->documentElement->appendChild($frag);
+
+    $oai_record = $dom->saveXML($dom->documentElement);
+  }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2120

* Other Relevant Links: https://groups.google.com/forum/#!msg/islandora/sP3D7fA9Pb8/4EcH1x4VAwAJ

# What does this Pull Request do?

Defines a drupal_alter() hook that allows modules to modify the outgoing DC, MODS, etc. in the OAI-PMH response. The purpose of the new hook is to provide a lighter-weight alternative to creating a custom request handler.

# What's new?

The addition of `drupal_alter('islandora_oai_record', $oai_output, $params);` to the end of the `islandora_oai_object_response_xml()` function in `includes/handler.inc`, just before the XML is returned.

Also, the addition of documentation for the new hook in islandora_oai.api.php.

# How should this be tested?

1. Check out the mjordan:7.x-ISLANDORA-2120 branch on your Vagrant.
1. Install https://github.com/mjordan/islandora_2120_test on your Vagrant.
1. If you need a simple OAI-PMH harvester, install https://github.com/mjordan/islandora_2120_oai_harvester on a system that has the PHP CLI installed. You can use any harvester you want, however.
1. In the harvester script, make sure the `$set` variable has a value based on an Islandora collection that has some objects in it.
1. Harvest some `oai_dc` records. They will all have a dc:description element added to them like `<dc:description>This record was harvested on a Wednesday.</dc:description>`.


# Additional Notes:

* Does this change require documentation to be updated? 

No.

* Does this change add any new dependencies? 

No.

* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 

No.

* Could this change impact execution of existing code?

No.

# Interested parties
@jordandukart as component manager, @Islandora/7-x-1-x-committers
