### PR TITLE
ISLANDORA-2234: Add support for oai_qdc metadata format

### DIFF
--- a/islandora_oai.install
+++ b/islandora_oai.install
@@ -43,6 +43,17 @@ function islandora_oai_install() {
       'record_namespace' => 'http://www.loc.gov/mods/v3',
     ))
     ->execute();
+
+  db_insert('islandora_oai_metadata_formats')
+    ->fields(array(
+      'name' => 'qdc',
+      'metadata_prefix' => 'oai_qdc',
+      'oai2_schema' => 'http://dublincore.org/schemas/xmls/qdc/2008/02/11/qualifieddc.xsd',
+      'metadata_namespace' => 'http://purl.org/dc/terms/',
+      'record_prefix' => 'dc',
+      'record_namespace' => 'http://purl.org/dc/terms/',
+    ))
+    ->execute();
 }
 
 /**
@@ -232,5 +243,21 @@ function islandora_oai_update_7102() {
     ))
     ->condition('name', 'oai_etdms')
     ->condition('metadata_prefix', 'oai_etdms')
+    ->execute();
+}
+
+/**
+ * Add support for QDC.
+ */
+function islandora_oai_update_7103(&$sandbox) {
+  db_insert('islandora_oai_metadata_formats')
+    ->fields(array(
+      'name' => 'qdc',
+      'metadata_prefix' => 'oai_qdc',
+      'oai2_schema' => 'http://dublincore.org/schemas/xmls/qdc/2008/02/11/qualifieddc.xsd',
+      'metadata_namespace' => 'http://purl.org/dc/terms/',
+      'record_prefix' => 'dc',
+      'record_namespace' => 'http://purl.org/dc/terms/',
+    ))
     ->execute();
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2234

# What does this Pull Request do?
Adds support for QDC Metadata format. Provides a new entry in the schema as well as an update hook.

# How should this be tested?
* After pulling down the changes, run a `drush updb` and install the new update.
* Make a request to your repository to list the available formats, this can be done by hitting:
`http://your.site/oai2?verb=ListMetadataFormats`
* Ensure that there's an entry for `oai_qdc`.

# Interested parties
@jordandukart to ping @Islandora/7-x-1-x-committers :-)