### PR TITLE
Make metadataPrefix queries case sensitive

### DIFF
--- a/includes/handler.inc
+++ b/includes/handler.inc
@@ -183,7 +183,7 @@ function islandora_oai_object_response_xml($params) {
     // See if we need to XPath to a specific spot to add it.
     $dom = new DOMDocument();
     $dom->loadXML($oai_output);
-    $results = db_query('SELECT * FROM {islandora_oai_metadata_formats} WHERE metadata_prefix = :metadata_prefix', array(':metadata_prefix' => $params['metadata_prefix']));
+    $results = db_query('SELECT * FROM {islandora_oai_metadata_formats} WHERE BINARY metadata_prefix = :metadata_prefix', array(':metadata_prefix' => $params['metadata_prefix']));
     $record = $results->fetchObject();
 
     $object_url = url("islandora/object/{$object->id}", array(
@@ -549,6 +549,7 @@ function islandora_oai_query_solr($start = 0, $field = 'PID', $query = NULL, $se
   }
   catch (Exception $e) {
     drupal_set_message(t('error searching @message', array('@message' => $e->getMessage())), 'error');
+    $solr_results = array();
   }
   return $solr_results;
 }
@@ -590,8 +591,6 @@ function islandora_oai_build_membership_fq_statement(array $children) {
  *   A list of set PIDs.
  */
 function islandora_oai_query_solr_for_child_sets($parent, &$sets = array()) {
-  global $user;
-  $user_name = $user->uid === 0 ? 'anonymous' : $user->name;
 
   module_load_include('inc', 'islandora_solr', 'includes/utilities');
   $qp = new IslandoraSolrQueryProcessor();

--- a/includes/request.inc
+++ b/includes/request.inc
@@ -314,7 +314,7 @@ function islandora_oai_get_record(&$writer, $args) {
         break;
 
       case 'metadataPrefix':
-        $result = db_query("SELECT * FROM {islandora_oai_metadata_formats} WHERE metadata_prefix=:metadata_prefix", array(':metadata_prefix' => $val));
+        $result = db_query("SELECT * FROM {islandora_oai_metadata_formats} WHERE BINARY metadata_prefix=:metadata_prefix", array(':metadata_prefix' => $val));
         if ($result->rowCount() > 0) {
           $metadata_prefix = $val;
         }
@@ -602,7 +602,7 @@ function islandora_oai_list_id_rec(&$writer, $args, $list_rec = FALSE) {
 
       case 'metadataPrefix':
         if (!isset($metadata_prefix)) {
-          $result = db_query("SELECT * FROM {islandora_oai_metadata_formats} WHERE metadata_prefix=:metadata_prefix ", array(':metadata_prefix' => $val));
+          $result = db_query("SELECT * FROM {islandora_oai_metadata_formats} WHERE BINARY metadata_prefix=:metadata_prefix ", array(':metadata_prefix' => $val));
 
           if ($result->rowCount() > 0 && !isset($metadata_prefix)) {
             $metadata_prefix = $val;
@@ -919,7 +919,7 @@ EOQ;
         break;
 
       case 'metadataPrefix':
-        $result = db_query("SELECT * FROM {islandora_oai_metadata_formats} WHERE metadata_prefix=:metadata_prefix", array(':metadata_prefix' => $val));
+        $result = db_query("SELECT * FROM {islandora_oai_metadata_formats} WHERE BINARY metadata_prefix=:metadata_prefix", array(':metadata_prefix' => $val));
         if ($result->rowCount() > 0) {
           $metadata_prefix = $val;
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1975

# What does this Pull Request do?

Makes the SQL query for the requested metadataPrefix case sensitive.

# What's new?

According to the OAI-PMH spec harvesters are supposed to use the metadata formats listed by a `verb=ListMetadataFormats` request.

In this implementation if the results of that is
```
<?xml version="1.0"?>
<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
  <responseDate>2018-10-18T15:51:13Z</responseDate>
  <request>http://digitalcollections.lib.umanitoba.ca/oai2</request>
  <ListMetadataFormats>
    <metadataFormat>
      <metadataPrefix>mods</metadataPrefix>
      <schema>http://www.loc.gov/standards/mods/v3/mods-3-4.xsd</schema>
      <metadataNamespace>http://www.loc.gov/mods/v3</metadataNamespace>
    </metadataFormat>
    <metadataFormat>
      <metadataPrefix>oai_dc</metadataPrefix>
      <schema>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</schema>
      <metadataNamespace>http://www.openarchives.org/OAI/2.0/oai_dc/</metadataNamespace>
    </metadataFormat>
    <metadataFormat>
      <metadataPrefix>oai_etdms</metadataPrefix>
      <schema>http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd</schema>
      <metadataNamespace>http://www.ndltd.org/standards/metadata/etdms/1.0/</metadataNamespace>
    </metadataFormat>
  </ListMetadataFormats>
</OAI-PMH>
```

Then you should perform your requests with a `metadataPrefix` of `mods`, `oai_dc` or `oai_etdms`.

However you can perform a request with `OAI_DC`, `Oai_dc` or any case-insensitive derivative.

This changes the output as the inserted identifier **ONLY** works if the request has the expected metadataPrefix of `oai_dc` (or `mods`, `oai_etdms`). Otherwise you get the full record without the identifer.

This PR changes the default behaviour to reject requests with non-expected case, for example.
```
<error code="cannotDisseminateFormat">The metadata format 'oai_DC' given by metadataPrefix is not supported by this repository.</error>
```

# How should this be tested?

Before PR.
1. On the page Administration » Islandora » Islandora Utility Modules » Islandora OAI » Islandora OAI Request Handler for one (or all) of the metadata formats check the the "Force include a link to the object within Islandora?" box.
1. Then perform a `GetRecord` request using the correct (lowercase) `metadataPrefix` (ie. `oai_dc`) and an uppercase or mixed case format (ie. `OAI_DC` or `OAI_dc`).
1. See that the injected 
     ```
     <dc:identifier>http://localhost/islandora/object/islandora%3A55</dc:identifier>
     ```
     appears and disappears.
1. Pull down the PR (possibly clear caches) and see that lowercase still works and different case does not.


# Additional Notes:
This may cause an impact if some harvester code is not using the metadataPrefixes as returned by the `ListMetadataPrefixes` command.

Also the removal of `$user_name` was because it was not used and the setting of `$results` was to avoid returning an undefined variable. These changes are just clean-up and not related to the work of this PR. If desired I can remove them.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? yes, see above.

# Interested parties
@Islandora/7-x-1-x-committers
