### PR TITLE
Address ISLANDORA-2473; use same variable name for reading and writing

### DIFF
--- a/includes/handler.admin.inc
+++ b/includes/handler.admin.inc
@@ -88,7 +88,6 @@ function islandora_oai_handler_configuration_form(array $form, array &$form_stat
     $metadata_format_options[$row->name] = drupal_strtoupper($row->name);
     $metadata_formats[$row->name] = $row;
   }
-
   $form['islandora_oai_metadata'] = array(
     '#type' => 'fieldset',
     '#title' => t('Metadata Format'),
@@ -114,8 +113,8 @@ function islandora_oai_handler_configuration_form(array $form, array &$form_stat
   $transform_options = array_merge($transform_options, $oai_invoke_files);
 
   foreach ($metadata_formats as $format) {
-    $default_transform = variable_get("islandora_oai_transform_file_$format->name", 'default');
-    $default_self_transform = variable_get("islandora_oai_self_transform_file_$format->name", 'default');
+    $default_transform = variable_get("islandora_oai_transform_file_$format->metadata_prefix", 'default');
+    $default_self_transform = variable_get("islandora_oai_self_transform_file_$format->metadata_prefix", 'default');
     $form['islandora_oai_metadata'][$format->name]['islandora_oai_metadata_prefix'] = array(
       '#type' => 'item',
       '#title' => t('Metadata Prefix'),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2473

# What does this Pull Request do?

Updates the code so the variable name is the same when reading and writing the var for self transform and transform.

# How should this be tested?
- Select QDC metadata in OAI admin
- Select and save a self transform and transform for QDC.
- Reload the settings for the QDC metadata format, the saved values for self transform and transform should be set in the form.

# Interested parties
@jordandukart  as maintainer @Islandora/7-x-1-x-committers
